### PR TITLE
Fix the `incompatible properties` problem

### DIFF
--- a/src/lib/util/resolveSwagger.ts
+++ b/src/lib/util/resolveSwagger.ts
@@ -303,14 +303,11 @@ export class ResolveSwagger {
     //  it identifies the URI of a schema to use. 
     //  All other properties in a "$ref" object MUST be ignored.
     //
-    if (parentProperty.$ref && unwrappedProperty.$ref) {
-      return this.isEqual(this.dereference(parentProperty.$ref), this.dereference(unwrappedProperty.$ref))
-    }
-    if (parentProperty.$ref) {
-      return this.isEqual(this.dereference(parentProperty.$ref), unwrappedProperty)
-    }
-    if (unwrappedProperty.$ref) {
-      return this.isEqual(parentProperty, this.dereference(unwrappedProperty.$ref))
+    if (parentProperty.$ref || unwrappedProperty.$ref) {
+      return this.isEqual(
+        parentProperty.$ref ? this.dereference(parentProperty.$ref) : parentProperty,
+        unwrappedProperty.$ref ? this.dereference(unwrappedProperty.$ref) : unwrappedProperty
+      )
     }
 
     if ((!parentProperty.type || parentProperty.type === "object") && (!unwrappedProperty.type || unwrappedProperty.type === "object")) {

--- a/src/lib/util/resolveSwagger.ts
+++ b/src/lib/util/resolveSwagger.ts
@@ -293,6 +293,26 @@ export class ResolveSwagger {
     if (!unwrappedProperty) {
       throw new Error("Null unwrapped property.")
     }
+
+    // Note: per https://editor-next.swagger.io/ tooltip when hovering over '$ref', 
+    // other properties must be ignored when $ref is present:
+    //
+    //  $ref: string
+    //  Any time a subschema is expected, a schema may instead use an object containing a "$ref" property. 
+    //  The value of the $ref is a URI Reference. Resolved against the current URI base, 
+    //  it identifies the URI of a schema to use. 
+    //  All other properties in a "$ref" object MUST be ignored.
+    //
+    if (parentProperty.$ref && unwrappedProperty.$ref) {
+      return this.isEqual(this.dereference(parentProperty.$ref), this.dereference(unwrappedProperty.$ref))
+    }
+    if (parentProperty.$ref) {
+      return this.isEqual(this.dereference(parentProperty.$ref), unwrappedProperty)
+    }
+    if (unwrappedProperty.$ref) {
+      return this.isEqual(parentProperty, this.dereference(unwrappedProperty.$ref))
+    }
+
     if ((!parentProperty.type || parentProperty.type === "object") && (!unwrappedProperty.type || unwrappedProperty.type === "object")) {
       let parentPropertyToCompare = parentProperty
       let unwrappedPropertyToCompare = unwrappedProperty


### PR DESCRIPTION
Details here:

- https://github.com/Azure/openapi-diff/pull/329#issuecomment-2126424120

To locally confirm this works:

1. `cd` to local clone root dir
2. `npx tsc && npx jest -t "compatible-properties-ref"`
3. It shall pass.